### PR TITLE
Added support for errors in nested changesets.

### DIFF
--- a/test/explode_test.exs
+++ b/test/explode_test.exs
@@ -73,6 +73,52 @@ defmodule ExplodeTest do
       "statusCode" => 400}
   end
 
+  test "use nested errors from an Ecto.Changeset" do
+    changeset = %Ecto.Changeset{
+      action: :insert,
+      types: %{
+        name: :string,
+        dummy: :integer,
+        pages: {:assoc, %Ecto.Association.ManyToMany{
+          field: :pages,
+          defaults: [],
+          cardinality: :many
+        }}
+      },
+      changes: %{
+        dummy: 4,
+        pages: [
+          %Ecto.Changeset{
+            types: %{},
+            action: :insert,
+            changes: %{name: "test", type: "text"},
+            errors: [],
+            valid?: true
+            },
+          %Ecto.Changeset{
+            types: %{},
+            action: :insert,
+            changes: %{type: "text"},
+            errors: [name: {"can't be blank", [validation: :required]}],
+            valid?: false
+          }
+        ]
+      },
+      errors: [name: {"can't be blank", [validation: :required]}],
+      valid?: false
+    }
+    
+    conn =
+      conn(:get, "/api/v1/things")
+      |> Explode.with(changeset)
+
+    assert conn.state == :sent
+    assert Poison.decode!(conn.resp_body) == %{
+      "error" => "Bad Request",
+      "message" => "`name` can't be blank, `pages` `name` can't be blank",
+      "statusCode" => 400}
+  end
+
   test "common-name functions for each status code without a message" do
     conn =
       conn(:get, "/api/v1/things")


### PR DESCRIPTION
This pull request would resolve #3 . Do note that I'm not super experienced with Elixir, and any suggestions for improvements on how to handle this would be more than welcome. I hope you might consider this useful.

When trying to explode with a changeset with cast_assoc

```
  def changeset(version, attrs) do
    version
    |> cast(attrs, [:name])
    |> cast_assoc(:pages, attrs["pages"])
    |> validate_required([:name])
  end
```

the server would error out when parsing the changeset with the error

```
(...)cannot convert the given list to a string.

[%{}, %{name: ["can't be blank"]}]
```

This fixes the issue, and provides the errors of nested changesets as well, as seen in the added test.

`` `name` can't be blank, `pages` `name` can't be blank``

## Issues

I was slightly unsure how to format the message, right now the formatting for deeply nested errors would be as follows

`` `name` can't be blank, `pages` `name` can't be blank, `test` `name` can't be blank ``
Paranthesis added for clarity:
`` (`name` can't be blank), (`pages` (`name` can't be blank), (`test` (`name` can't be blank))) ``

* Object.name -> cant be blank
* Object.pages.name -> can't be blank
* Object.pages.test.name -> can't be blank

It's not entirely obvious when reading the message without knowing how it is structured beforehand. Could potentially do something like pass down the parent object name and use `pages.name` and `pages.test.name`.